### PR TITLE
Change a method to get event.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 htmlcov
 .coverage
 kleros.db
+.idea

--- a/kleros.py
+++ b/kleros.py
@@ -15,7 +15,7 @@ class Kleros:
     def last_dispute_id(self):
         filter = self.connection.events.DisputeCreation.createFilter(fromBlock=7303699,
             argument_filters={"topic0": "0x141dfc18aa6a56fc816f44f0e9e2f1ebc92b15ab167770e17db5b084c10ed995"} )
-        self.last_dispute_id = filter.get_all_entries()[-1]['args']['_disputeID']
+        self.last_dispute_id = filter.get_new_entries()['args']['_disputeID']
         return self.last_dispute_id
 
 class KlerosDispute(Kleros):


### PR DESCRIPTION
I checked our code and found that we use 
```
Filter.get_all_entries()
``` 
to get events, but I think it will return all entries for this filter, so maybe we can change to another function 
```
Filter.get_new_entries()
```
this  returns only new entries since the last poll.